### PR TITLE
Update link to the new location in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # This repository was moved
 
-For the development of AeroDoc backend, please visit https://github.com/aerogear/aerogear-backend-cookbook/tree/master/aerodoc-backend
+For the development of AeroDoc backend, please visit https://github.com/aerogear/aerogear-backend-cookbook/tree/master/AeroDoc
 
 


### PR DESCRIPTION
Apparently, the source directory was [renamed a year ago](https://github.com/aerogear/aerogear-backend-cookbook/commit/619f601c203e1c7622560e50f8607d01da0881ef), and the [docs](https://aerogear.org/getstarted/demos/) still point here.